### PR TITLE
Simplification of initial seeding behaviour

### DIFF
--- a/server/common/src/main/resources/application.conf
+++ b/server/common/src/main/resources/application.conf
@@ -3,7 +3,6 @@
 #   APP_ADDR - IP Address for our host (here we need to ensure the Weave NIC is used!)
 #   ETCD_URL - URL pointing to our compute nodes etcd service
 #   JOURNAL  - IP Address for our Cassandra journal node
-#   ROLES    - comma separated list of strings that describe the roles that this actor system possesses
 #   SNAPSHOT - IP Address for our Cassandra snapshot node
 
 # Logging knobs - twiddle to set appropriately
@@ -58,7 +57,6 @@ akka {
     log-info = ${logging.cluster}
     auto-down-unreachable-after = 10s # FIXME: should we really be auto-downing?
     retry = 10s
-    roles = [ ${?ROLES} ]
   }
 
   persistence {


### PR DESCRIPTION
Initial seed node now determined by Akka cluster node discovering its own etcd state has been set to `MemberUp`. This is achieved using the Fleet unit script `seed@.service`.
