### PR TITLE
Bug fix: ensure shardRegion acts in proxy mode on relevant actor systems

### DIFF
--- a/server/common/src/main/scala/com/eigengo/lift/common/MicroserviceApp.scala
+++ b/server/common/src/main/scala/com/eigengo/lift/common/MicroserviceApp.scala
@@ -75,13 +75,10 @@ abstract class MicroserviceApp(microserviceProps: MicroserviceProps)(boot: Actor
     // resolve the local host name
     val hostname = InetAddress.getLocalHost.getHostAddress
     log.info(s"Starting Up microservice $microserviceProps at $hostname")
-    Thread.sleep(10000)
 
     // load config and set Up etcd client
     import scala.concurrent.duration._
-    val clusterShardingConfig = ConfigFactory.parseString(s"akka.contrib.cluster.sharding.role=${microserviceProps.role}")
-    val clusterRoleConfig = ConfigFactory.parseString(s"akka.cluster.roles=['${microserviceProps.role}']")
-    val config = clusterShardingConfig.withFallback(clusterRoleConfig).withFallback(ConfigFactory.load())
+    val config = ConfigFactory.load()
     val etcd = new EtcdClient(config.getString("etcd.url"))
     log.info(s"Config loaded; etcd expected at $etcd")
 

--- a/server/profile/src/main/scala/com/eigengo/lift/profile/UserProfileBoot.scala
+++ b/server/profile/src/main/scala/com/eigengo/lift/profile/UserProfileBoot.scala
@@ -3,8 +3,8 @@ package com.eigengo.lift.profile
 import akka.actor.{ActorSystem, ActorRef}
 import akka.contrib.pattern.ClusterSharding
 import com.eigengo.lift.common.MicroserviceApp.BootedNode
-
 import scala.concurrent.ExecutionContext
+import scala.collection.JavaConversions._
 
 case class UserProfileBoot(userProfile: ActorRef, private val userProfileProcessor: ActorRef)
   extends UserProfileService with BootedNode {
@@ -15,9 +15,10 @@ case class UserProfileBoot(userProfile: ActorRef, private val userProfileProcess
 object UserProfileBoot {
 
   def boot(system: ActorSystem): UserProfileBoot = {
+    val roles = system.settings.config.getStringList("akka.cluster.roles")
     val userProfile = ClusterSharding(system).start(
       typeName = UserProfileLink.userProfileShardName,
-      entryProps = Some(UserProfile.props),
+      entryProps = roles.find("profile" ==).map(_ => UserProfile.props),
       idExtractor = UserProfileProtocol.idExtractor,
       shardResolver = UserProfileProtocol.shardResolver)
     val userProfileProcessor = system.actorOf(UserProfileProcessor.props(userProfile), UserProfileProcessor.name)


### PR DESCRIPTION
`ShardRegion` proxy mode can be activated either by setting the config properties:
- `akka.cluster.roles`
- and `akka.contrib.cluster.sharding.role` (so that it isn't in the `akka.cluster.roles` list)

or, by ensuring that `Props` are `None` when creating the shard region.

Given that the Docker container sets `akka.cluster.roles` when launching a specific Akka container (e.g. see current [lift/exercise@.service.erb](https://github.com/carlpulley/coreos-vagrant/blob/master/unit-files/lift/exercise%40.service.erb) and [lift/profile@.service.erb](https://github.com/carlpulley/coreos-vagrant/blob/master/unit-files/lift/profile%40.service.erb)), then it is probably easiest to use the `None` method of proxying when we boot the service. This PR provides code for doing this.
