### PR TITLE
UITableView exclusive selection fix

### DIFF
--- a/ios/Lift/LiveSessionController.swift
+++ b/ios/Lift/LiveSessionController.swift
@@ -155,10 +155,6 @@ class LiveSessionController: UITableViewController, UITableViewDelegate, UITable
         }
     }
     
-    override func tableView(tableView: UITableView, didDeselectRowAtIndexPath indexPath: NSIndexPath) {
-        return
-    }
-    
     override func tableView(tableView: UITableView, heightForRowAtIndexPath indexPath: NSIndexPath) -> CGFloat {
         switch (indexPath.section, indexPath.row) {
         case (0, 0): return 60

--- a/ios/Lift/LiveSessionController.swift
+++ b/ios/Lift/LiveSessionController.swift
@@ -141,6 +141,7 @@ class LiveSessionController: UITableViewController, UITableViewDelegate, UITable
                         let indexPath = NSIndexPath(forRow: i, inSection: 1)
                         if (tableView.cellForRowAtIndexPath(indexPath)!.accessoryType == UITableViewCellAccessoryType.Checkmark) {
                             tableView.cellForRowAtIndexPath(indexPath)!.accessoryType = UITableViewCellAccessoryType.None
+                            session?.endExplicitClassification()
                         }
                     }
                     selectedCell.accessoryType = UITableViewCellAccessoryType.Checkmark
@@ -157,10 +158,6 @@ class LiveSessionController: UITableViewController, UITableViewDelegate, UITable
     override func tableView(tableView: UITableView, didDeselectRowAtIndexPath indexPath: NSIndexPath) {
         if let selectedCell = tableView.cellForRowAtIndexPath(indexPath) {
             switch selectedCell.accessoryType {
-                //If it was still checked, send delete request before unchecking
-            case UITableViewCellAccessoryType.Checkmark:
-                selectedCell.accessoryType = UITableViewCellAccessoryType.None
-                session?.endExplicitClassification()
             default: return
             }
         }

--- a/ios/Lift/LiveSessionController.swift
+++ b/ios/Lift/LiveSessionController.swift
@@ -156,11 +156,7 @@ class LiveSessionController: UITableViewController, UITableViewDelegate, UITable
     }
     
     override func tableView(tableView: UITableView, didDeselectRowAtIndexPath indexPath: NSIndexPath) {
-        if let selectedCell = tableView.cellForRowAtIndexPath(indexPath) {
-            switch selectedCell.accessoryType {
-            default: return
-            }
-        }
+        return
     }
     
     override func tableView(tableView: UITableView, heightForRowAtIndexPath indexPath: NSIndexPath) -> CGFloat {
@@ -179,7 +175,7 @@ class LiveSessionController: UITableViewController, UITableViewDelegate, UITable
             x.submitData(mp, const(()))
 
             if UIApplication.sharedApplication().applicationState != UIApplicationState.Background {
-                tableView.reloadData()
+                tableView.reloadSections(NSIndexSet(index: 0), withRowAnimation: UITableViewRowAnimation.None)
             }
         } else {
             RKDropdownAlert.title("Internal inconsistency", message: "AD received, but no sessionId.", backgroundColor: UIColor.orangeColor(), textColor: UIColor.blackColor(), time: 3)


### PR DESCRIPTION
As reported by @janm399 in issue #39 : when the iOS device is connected to a Pebble and receiving data, the tick-boxes indicating explicit classification get deselected. I believe it's due to the first section with the Pebble information being updated triggering the `didDeselectRowAtIndexPath` method. 

- [x] Make the fix
- [x] Test the fix

Fix: Simple case of reloading the first section and not the second one