### PR TITLE
Offline mode integration

### DIFF
--- a/ios/Lift WatchKit App/Interface.storyboard
+++ b/ios/Lift WatchKit App/Interface.storyboard
@@ -21,10 +21,34 @@
             <objects>
                 <glanceController spacing="0.0" id="0uZ-2p-rRc" customClass="GlanceController" customModule="Lift_WatchKit_App" customModuleProvider="target">
                     <items>
-                        <group alignment="left" id="t8f-Gd-c4y"/>
-                        <group alignment="left" id="uCw-4Q-Ouw"/>
+                        <group alignment="left" layout="vertical" id="F47-4d-YF4">
+                            <items>
+                                <timer width="83.5" alignment="left" previewedSeconds="1733" id="mB0-5u-luZ"/>
+                                <label width="119.5" alignment="left" text="Arms" textAlignment="left" id="zgo-dN-0mm">
+                                    <fontDescription key="font" type="system" pointSize="20"/>
+                                </label>
+                            </items>
+                        </group>
+                        <group alignment="left" id="uCw-4Q-Ouw">
+                            <items>
+                                <table alignment="left" id="Lcc-7p-GOQ">
+                                    <items>
+                                        <tableRow identifier="set" id="9ge-HJ-7uz">
+                                            <group key="rootItem" width="1" alignment="left" id="rEx-Qm-HlJ">
+                                                <items>
+                                                    <label width="1" alignment="left" text="Bicep curl" id="cho-og-VVe"/>
+                                                </items>
+                                            </group>
+                                        </tableRow>
+                                    </items>
+                                </table>
+                            </items>
+                        </group>
                     </items>
                     <edgeInsets key="margins" left="0.0" right="0.0" top="0.0" bottom="14"/>
+                    <connections>
+                        <outlet property="tableView" destination="Lcc-7p-GOQ" id="EAq-GU-FoW"/>
+                    </connections>
                 </glanceController>
             </objects>
             <point key="canvasLocation" x="235" y="672"/>

--- a/ios/Lift WatchKit Extension/GlanceController.swift
+++ b/ios/Lift WatchKit Extension/GlanceController.swift
@@ -11,12 +11,12 @@ import Foundation
 
 
 class GlanceController: WKInterfaceController {
+    @IBOutlet var tableView: WKInterfaceTable!
 
     override func awakeWithContext(context: AnyObject?) {
         super.awakeWithContext(context)
         
-        // Configure interface objects here.
-        NSLog("%@ awakeWithContext", self)
+        tableView.setNumberOfRows(3, withRowType: "set")
     }
 
     override func willActivate() {

--- a/ios/Lift.xcodeproj/project.pbxproj
+++ b/ios/Lift.xcodeproj/project.pbxproj
@@ -69,6 +69,7 @@
 		54CC69A219C4AD8E00B29EC8 /* Main.storyboard in Resources */ = {isa = PBXBuildFile; fileRef = 54CC69A019C4AD8E00B29EC8 /* Main.storyboard */; };
 		54CC69A419C4AD8E00B29EC8 /* Images.xcassets in Resources */ = {isa = PBXBuildFile; fileRef = 54CC69A319C4AD8E00B29EC8 /* Images.xcassets */; };
 		54CC69BD19C4AE0E00B29EC8 /* CoreBluetooth.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 54CC69BC19C4AE0E00B29EC8 /* CoreBluetooth.framework */; };
+		54CFACB01A7568C700E3803C /* QuartzCore.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 54CFACAF1A7568C700E3803C /* QuartzCore.framework */; };
 		54D320811A276747002527C8 /* Alamofire.swift in Sources */ = {isa = PBXBuildFile; fileRef = 54D320801A276747002527C8 /* Alamofire.swift */; };
 		54D8DD2A1A2E58660005E2ED /* DemoSessionController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 54D8DD291A2E58660005E2ED /* DemoSessionController.swift */; };
 		54D8DD2C1A2E59FA0005E2ED /* ExerciseSession.swift in Sources */ = {isa = PBXBuildFile; fileRef = 54D8DD2B1A2E59FA0005E2ED /* ExerciseSession.swift */; };
@@ -227,6 +228,7 @@
 		54CC69AC19C4AD8E00B29EC8 /* LiftTests.xctest */ = {isa = PBXFileReference; explicitFileType = wrapper.cfbundle; includeInIndex = 0; path = LiftTests.xctest; sourceTree = BUILT_PRODUCTS_DIR; };
 		54CC69B119C4AD8E00B29EC8 /* Info.plist */ = {isa = PBXFileReference; lastKnownFileType = text.plist.xml; path = Info.plist; sourceTree = "<group>"; };
 		54CC69BC19C4AE0E00B29EC8 /* CoreBluetooth.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = CoreBluetooth.framework; path = System/Library/Frameworks/CoreBluetooth.framework; sourceTree = SDKROOT; };
+		54CFACAF1A7568C700E3803C /* QuartzCore.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = QuartzCore.framework; path = System/Library/Frameworks/QuartzCore.framework; sourceTree = SDKROOT; };
 		54D3207F1A276747002527C8 /* Alamofire.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = Alamofire.h; sourceTree = "<group>"; };
 		54D320801A276747002527C8 /* Alamofire.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = Alamofire.swift; sourceTree = "<group>"; };
 		54D8DD291A2E58660005E2ED /* DemoSessionController.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = DemoSessionController.swift; sourceTree = "<group>"; };
@@ -276,6 +278,7 @@
 			isa = PBXFrameworksBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
+				54CFACB01A7568C700E3803C /* QuartzCore.framework in Frameworks */,
 				549ED2B21A6D8884002588B9 /* libxml2.dylib in Frameworks */,
 				549ED2AD1A6D8867002588B9 /* libPods-LiftTests-CocoaAsyncSocket.a in Frameworks */,
 				549ED2AE1A6D8867002588B9 /* libPods-LiftTests-CocoaHTTPServer.a in Frameworks */,
@@ -560,6 +563,7 @@
 		8D64789A58A65961D3659708 /* Frameworks */ = {
 			isa = PBXGroup;
 			children = (
+				54CFACAF1A7568C700E3803C /* QuartzCore.framework */,
 				549ED2B11A6D8884002588B9 /* libxml2.dylib */,
 				549ED2A91A6D8867002588B9 /* libPods-LiftTests-CocoaAsyncSocket.a */,
 				549ED2AA1A6D8867002588B9 /* libPods-LiftTests-CocoaHTTPServer.a */,

--- a/ios/Lift/LiftServer/MutableMultiPacket.swift
+++ b/ios/Lift/LiftServer/MutableMultiPacket.swift
@@ -1,4 +1,13 @@
 import Foundation
+import QuartzCore
+
+///
+/// Saves the multi packet value
+///
+enum MutableMultiPacketEntry {
+    case Data(data: NSMutableData)
+    case Empty
+}
 
 /**
  * Provides builder for the MultiPacket structure. Make an instance of it, then call
@@ -6,17 +15,17 @@ import Foundation
  * ``NSData`` that can be sent & decoded on the server.
  */
 class MutableMultiPacket : MultiPacket {
-    private var buffer: [SensorDataSourceLocation : NSMutableData] = [:]
+    private var buffer: [SensorDataSourceLocation : MutableMultiPacketEntry] = [:]
     
     /**
      * Append ``data`` received from a sensor at ``location``. If there is already
      * value at the given ``location``, the passed ``data`` will be appended to it.
      */
     func append(location: SensorDataSourceLocation, data: NSData) -> Self {
-        if let x = buffer[location] {
-            x.appendData(data)
-        } else {
-            buffer[location] = NSMutableData(data: data)
+        switch buffer[location] {
+        case .Some(.Data(data: let x)): x.appendData(data)
+        case .Some(.Empty): buffer[location] = MutableMultiPacketEntry.Data(data: NSMutableData(data: data))
+        case .None: buffer[location] = MutableMultiPacketEntry.Data(data: NSMutableData(data: data))
         }
         
         return self
@@ -27,14 +36,30 @@ class MutableMultiPacket : MultiPacket {
      */
     func data() -> NSData {
         let result = NSMutableData()
-        let header: [UInt8] = [0xca, 0xb0, UInt8(buffer.count)]
+        let header: [UInt8] = [0xca, 0xb1, UInt8(buffer.count)]
         result.appendBytes(header, length: 3)
-        for (sdsl, data) in buffer {
-            let sizel = UInt8(data.length & 0xff00 >> 8)
-            let sizeh = UInt8(data.length >> 8)
-            let dHeader: [UInt8] = [sizeh, sizel, sdsl.rawValue]
-            result.appendBytes(dHeader, length: 3)
-            result.appendData(data)
+        let timestampValue = Int(CACurrentMediaTime() * 1000)
+        let timestampBuffer: [UInt8] = [
+            UInt8((timestampValue & 0xff000000) >> 24),
+            UInt8((timestampValue & 0x00ff0000) >> 16),
+            UInt8((timestampValue & 0x0000ff00) >> 8),
+            UInt8(timestampValue & 0x000000ff)]
+        result.appendBytes(timestampBuffer, length: 4)
+        
+        for (sdsl, entry) in buffer {
+            switch entry {
+            case .Data(data: let data):
+                let sizel = UInt8(data.length & 0xff00 >> 8)
+                let sizeh = UInt8(data.length >> 8)
+                let dHeader: [UInt8] = [sizeh, sizel, sdsl.rawValue]
+                result.appendBytes(dHeader, length: 3)
+                result.appendData(data)
+            case .Empty:
+                let sizel = UInt8(0)
+                let sizeh = UInt8(0)
+                let dHeader: [UInt8] = [sizeh, sizel, sdsl.rawValue]
+                result.appendBytes(dHeader, length: 3)
+            }
         }
         
         return result

--- a/ios/LiftTests/LiftServer/MutableMultiPacketTests.swift
+++ b/ios/LiftTests/LiftServer/MutableMultiPacketTests.swift
@@ -10,31 +10,35 @@ class MutableMultiPacketTests : XCTestCase {
         let result = mp.data()
         
         // the output should be
-        // 0x00: 0xca 0xb0 0x03 (header)
-        // 0x03: 0x00 0x04 0x01 (4 B at wrist)  0xff 0x01 0x02 0x03 (payload 0)
-        // 0x0a: 0x00 0x02 0x02 (2 B at waist)  0xf0 0x01 (payload 1)
-        // 0x0f: 0xff 0xff 0x7f (64 kiB at any) 0x7f 0x7f ... (payload 2)
+        // 0x00:               0xca 0xb0 0x03 0xt0 0xt1 0xt2 0xt3 (header)
+        // h + 0x00:           0x00 0x04 0x01 (4 B at wrist)  0xff 0x01 0x02 0x03 (payload 0)
+        // h + _1 + 0x00:      0x00 0x02 0x02 (2 B at waist)  0xf0 0x01 (payload 1)
+        // h + _1 + _2 + 0x10: 0xff 0xff 0x7f (64 kiB at any) 0x7f 0x7f ... (payload 2)
         
+        let h = 7
+        let _1 = 3 + 4
+        let _2 = 3 + 2
+
         let x = UnsafePointer<UInt8>(result.bytes)
         XCTAssert(x[0x00] == 0xca, "Bad header 0")
-        XCTAssert(x[0x01] == 0xb0, "Bad header 1")
+        XCTAssert(x[0x01] == 0xb1, "Bad header 1")
         XCTAssert(x[0x02] == 0x03, "Bad header count")
         
-        XCTAssert(x[0x03] == 0x00, "Bad D header 0 size h")
-        XCTAssert(x[0x04] == 0x04, "Bad D header 0 size l")
-        XCTAssert(x[0x05] == 0x01, "Bad D header 0 sdsl")
-        XCTAssert(x[0x06] == 0xff, "Bad data 0 0") // 8, 9, 10
+        XCTAssert(x[h + 0x00] == 0x00, "Bad D header 0 size h")
+        XCTAssert(x[h + 0x01] == 0x04, "Bad D header 0 size l")
+        XCTAssert(x[h + 0x02] == 0x01, "Bad D header 0 sdsl")
+        XCTAssert(x[h + 0x03] == 0xff, "Bad data 0 0") // 8, 9, 10
         // ...
         
-        XCTAssert(x[0x0a] == 0x00, "Bad D header 1 size h")
-        XCTAssert(x[0x0b] == 0x02, "Bad D header 1 size l")
+        XCTAssert(x[h + _1 + 0x00] == 0x00, "Bad D header 1 size h")
+        XCTAssert(x[h + _1 + 0x01] == 0x02, "Bad D header 1 size l")
         // ...
         
-        XCTAssert(x[0x0f] == 0xff, "Bad D header 2 size h")
-        XCTAssert(x[0x10] == 0xff, "Bad D header 2 size l")
-        XCTAssert(x[0x11] == 0x7f, "Bad D header 2 sdsl")
-        XCTAssert(x[0x12] == 0x8f, "Bad data 2 0")
-        XCTAssert(x[0xffff + 0x11] == 0x8f, "Bad data 2 0xffff")
+        XCTAssert(x[h + _1 + _2 + 0x00] == 0xff, "Bad D header 2 size h")
+        XCTAssert(x[h + _1 + _2 + 0x01] == 0xff, "Bad D header 2 size l")
+        XCTAssert(x[h + _1 + _2 + 0x02] == 0x7f, "Bad D header 2 sdsl")
+        XCTAssert(x[h + _1 + _2 + 0x03] == 0x8f, "Bad data 2 0")
+        XCTAssert(x[h + _1 + _2 + 0xffff] == 0x8f, "Bad data 2 0xffff")
     }
     
 }

--- a/server/exercise/src/main/scala/com/eigengo/lift/exercise/ExerciseService.scala
+++ b/server/exercise/src/main/scala/com/eigengo/lift/exercise/ExerciseService.scala
@@ -89,6 +89,13 @@ trait ExerciseService extends Directives with ExerciseMarshallers {
         }
       }
     } ~
+    path("exercise" / UserIdValue / SessionIdValue / "abandon") { (userId, sessionId) ⇒
+      post {
+        complete {
+          (userExercises ? UserExerciseSessionAbandon(userId, sessionId)).mapRight[Unit]
+        }
+      }
+    } ~
     path("exercise" / UserIdValue / SessionIdValue / "classification") { (userId, sessionId) ⇒
       get {
         complete {

--- a/server/exercise/src/main/scala/com/eigengo/lift/exercise/MultiPacket.scala
+++ b/server/exercise/src/main/scala/com/eigengo/lift/exercise/MultiPacket.scala
@@ -4,10 +4,10 @@ import scodec.bits.BitVector
 
 case class PacketWithLocation(sourceLocation: SensorDataSourceLocation, payload: BitVector)
 
-case class MultiPacket(packets: List[PacketWithLocation]) {
+case class MultiPacket(timestamp: Long, packets: List[PacketWithLocation]) {
   def withNewPacket(packet: PacketWithLocation): MultiPacket = copy(packets = packets :+ packet)
 }
 
 object MultiPacket {
-  def single(pwl: PacketWithLocation): MultiPacket = MultiPacket(List(pwl))
+  def single(timestamp: Long)(pwl: PacketWithLocation): MultiPacket = MultiPacket(timestamp, List(pwl))
 }

--- a/server/exercise/src/main/scala/com/eigengo/lift/exercise/UserExercisesProcessor.scala
+++ b/server/exercise/src/main/scala/com/eigengo/lift/exercise/UserExercisesProcessor.scala
@@ -303,7 +303,7 @@ import scala.concurrent.duration._
         sender() ! \/.right(())
 
         // TODO: Implement proper replay handling. For now, we save the file and end the session.
-        val fos = new FileOutputStream(s"/Users/janmachacek/$newSessionId.mp")
+        val fos = new FileOutputStream(s"$newSessionId.mp")
         fos.write(data)
         fos.close()
 

--- a/server/exercise/src/main/scala/com/eigengo/lift/exercise/UserExercisesProcessor.scala
+++ b/server/exercise/src/main/scala/com/eigengo/lift/exercise/UserExercisesProcessor.scala
@@ -28,6 +28,13 @@ object UserExercisesProcessor {
   case class UserExerciseSessionDelete(userId: UserId, sessionId: SessionId)
 
   /**
+   * Abandons the session identified by ``userId`` and ``sessionId``
+   * @param userId the user identity
+   * @param sessionId the session identity
+   */
+  case class UserExerciseSessionAbandon(userId: UserId, sessionId: SessionId)
+
+  /**
    * Replay all data received for a possibly existing ``sessionId`` for the given ``userId``
    * @param userId the user identity
    * @param sessionId the session identity
@@ -156,6 +163,12 @@ object UserExercisesProcessor {
   private case class ExerciseExplicitClassificationEnd(sessionId: SessionId)
 
   /**
+   * Abandons the give exercise session
+   * @param sessionId the session identity
+   */
+  private case class ExerciseSessionAbandon(sessionId: SessionId)
+
+  /**
    * Starts the user exercise sessionProps
    * @param userId the user identity
    * @param sessionProps the sessionProps details
@@ -203,6 +216,7 @@ object UserExercisesProcessor {
     case UserExerciseSessionEnd(userId, sessionId)                            ⇒ (userId.toString, ExerciseSessionEnd(sessionId))
     case UserExerciseDataProcessMultiPacket(userId, sessionId, packets)       ⇒ (userId.toString, ExerciseDataProcessMultiPacket(sessionId, packets))
     case UserExerciseSessionDelete(userId, sessionId)                         ⇒ (userId.toString, ExerciseSessionDelete(sessionId))
+    case UserExerciseSessionAbandon(userId, sessionId)                        ⇒ (userId.toString, ExerciseSessionAbandon(sessionId))
     case UserExerciseSessionReplayProcessData(userId, sessionId, data)        ⇒ (userId.toString, ExerciseSessionReplayProcessData(sessionId, data))
     case UserExerciseSessionReplayStart(userId, sessionId, props)             ⇒ (userId.toString, ExerciseSessionReplayStart(sessionId, props))
     case UserExerciseExplicitClassificationStart(userId, sessionId, exercise) ⇒ (userId.toString, ExerciseExplicitClassificationStart(sessionId, exercise))
@@ -220,6 +234,7 @@ object UserExercisesProcessor {
     case UserExerciseSessionEnd(userId, _)                     ⇒ s"${userId.hashCode() % 10}"
     case UserExerciseDataProcessMultiPacket(userId, _, _)      ⇒ s"${userId.hashCode() % 10}"
     case UserExerciseSessionDelete(userId, _)                  ⇒ s"${userId.hashCode() % 10}"
+    case UserExerciseSessionAbandon(userId, _)                 ⇒ s"${userId.hashCode() % 10}"
     case UserExerciseExplicitClassificationStart(userId, _, _) ⇒ s"${userId.hashCode() % 10}"
     case UserExerciseExplicitClassificationEnd(userId, _)      ⇒ s"${userId.hashCode() % 10}"
     case UserExerciseExplicitClassificationExamples(userId, _) ⇒ s"${userId.hashCode() % 10}"
@@ -229,8 +244,22 @@ object UserExercisesProcessor {
 }
 
 /**
- * Models each user's exercises as its state, which is updated upon receiving and classifying the
- * ``AccelerometerData``. It also provides the query for the current state.
+ * Processes each user's exercise sessions. It contains three main states:
+ *
+ * - not exercising
+ * - exercising
+ * - replaying
+ *
+ * The sunny day flow is that this actor moves from not exercising to exercising, receives all
+ * sensor data from the client, and then moves back to not exercising.
+ *
+ * This actor can instruct the mobile to switch to offline session mode—that is to stop sending
+ * any sensor data, and prepare to send all sensor data in one block in a replay request—if it
+ * notices serious inconsistency in the received data.
+ *
+ * Finally, the client can replay an offline session by sending all sensor data in one request
+ * and this instance must process them as though it received the data by parts as part of an online
+ * session.
  */
 class UserExercisesProcessor(override val kafka: ActorRef, notification: ActorRef, userProfile: ActorRef)
   extends KafkaProducerPersistentActor
@@ -299,6 +328,14 @@ import scala.concurrent.duration._
     case ExerciseSessionEnd(`id`) ⇒
       log.debug("ExerciseSessionEnd: exercising -> not exercising.")
       persist(SessionEndedEvt(id)) { evt ⇒
+        saveSnapshot(evt)
+        context.become(notExercising)
+        sender() ! \/.right(())
+      }
+
+    case ExerciseSessionAbandon(`id`) ⇒
+      log.debug("ExerciseSessionEnd: exercising -> not exercising.")
+      persist(SessionAbandonedEvt(id)) { evt ⇒
         saveSnapshot(evt)
         context.become(notExercising)
         sender() ! \/.right(())

--- a/server/exercise/src/test/scala/com/eigengo/lift/exercise/ExerciseServiceTest.scala
+++ b/server/exercise/src/test/scala/com/eigengo/lift/exercise/ExerciseServiceTest.scala
@@ -33,7 +33,7 @@ object ExerciseServiceTest {
     val session = Some(ExerciseSession(sessionId, sessionProps, List(ExerciseSet(List(squat)))))
     val sessionDates = List(SessionDate(startDate, List(SessionIntensity(intensity.get, intensity.get))))
     val multiPacket: Array[Byte] = Array(
-      0xca, 0xb0, 0x02,
+      0xca, 0xb1, 0x02, 0x00, 0x00, 0x00, 0x00,
       0x00, 0x04, 0x01, 0xff, 0x01, 0x02, 0x03,
       0x00, 0x02, 0x02, 0xf0, 0x01).map(_.toByte)
     val emptyResponse = "{}"

--- a/server/exercise/src/test/scala/com/eigengo/lift/exercise/MultiPacketDecoderTest.scala
+++ b/server/exercise/src/test/scala/com/eigengo/lift/exercise/MultiPacketDecoderTest.scala
@@ -18,10 +18,19 @@ class MultiPacketDecoderTest extends FlatSpec with Matchers {
   }
 
   /// generate incoming message for the given slocs, sizes and content
-  private def generate(slocs: List[Byte], size: Byte ⇒ Int, content: (Byte, Int) ⇒ Array[Byte]): Array[Byte] = {
-    val header: Array[Byte] = Array.apply(0xca.toByte, 0xb0.toByte, slocs.size.toByte)
+  private def generate(ts: Long, slocs: List[Byte], size: Byte ⇒ Int, content: (Byte, Int) ⇒ Array[Byte]): Array[Byte] = {
+    val header: Array[Byte] = Array.apply(0xca.toByte, 0xb1.toByte, slocs.size.toByte)
+    val timestamp: Array[Byte] = encodeTimestamp(ts)
     val payloads = slocs.map { sloc ⇒ val s = size(sloc); payload(s, sloc, content(sloc, s)) }
-    payloads.foldLeft(header)(_ ++ _)
+    payloads.foldLeft(header ++ timestamp)(_ ++ _)
+  }
+
+  private def encodeTimestamp(ts: Long): Array[Byte] = {
+    val ts0 = ((ts & 0xff000000) >> 24).toByte
+    val ts1 = ((ts & 0x00ff0000) >> 16).toByte
+    val ts2 = ((ts & 0x0000ff00) >> 8).toByte
+    val ts3 = (ts & 0x000000ff).toByte
+    Array(ts0, ts1, ts2, ts3)
   }
 
   private def constSize(s: Int)(sloc: Byte): Int = s
@@ -29,25 +38,26 @@ class MultiPacketDecoderTest extends FlatSpec with Matchers {
   private def badContent(sloc: Byte, size: Int): Array[Byte] = Array.empty
 
   "Single valid packet" should "decode" in {
-    val \/-(x) = MultiPacketDecoder.decode(ByteBuffer.wrap(generate(List(0x01), constSize(1), constContent(0x00))))
+    val \/-(x) = MultiPacketDecoder.decode(ByteBuffer.wrap(generate(12345678, List(0x01), constSize(1), constContent(0x00))))
+    x.timestamp should be(12345678)
     x.packets(0).payload.getByte(0) should be(0)
   }
 
   "Multiple valid, max size packets" should "decode" in {
-    val in = generate(List(0x01, 0x02, 0x03, 0x04, 0x7f), constSize(65535), constContent(0x7f))
+    val in = generate(12345678, List(0x01, 0x02, 0x03, 0x04, 0x7f), constSize(65535), constContent(0x7f))
     val \/-(x) = MultiPacketDecoder.decode(ByteBuffer.wrap(in))
     x.packets.size should be (5)
     x.packets.foreach(_.payload.getByte(0) should be(0x7f))
   }
 
   "Very badly malformed input" should "fail decoding" in {
-    val -\/("No viable input: size < 7.") = MultiPacketDecoder.decode(ByteBuffer.wrap(Array.empty))
-    val -\/("Incorrect header. Expected -13648, got 0.") = MultiPacketDecoder.decode(ByteBuffer.wrap(Array.fill(7)(0)))
-    val -\/("No content.") = MultiPacketDecoder.decode(ByteBuffer.wrap(Array[Byte](0xca.toByte, 0xb0.toByte, 0x00, 0x00, 0x00, 0x00, 0x00)))
+    val -\/("No viable input: size < 10.") = MultiPacketDecoder.decode(ByteBuffer.wrap(Array.empty))
+    val -\/("Incorrect header. Expected -13647, got 0.") = MultiPacketDecoder.decode(ByteBuffer.wrap(Array.fill(10)(0)))
+    val -\/("No content.") = MultiPacketDecoder.decode(ByteBuffer.wrap(Array[Byte](0xca.toByte, 0xb1.toByte, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00)))
   }
 
   "Malformed content" should "fail decoding" in {
-    val in = generate(List(0x01, 0x02, 0x03, 0x04, 0x7f), constSize(65535), badContent)
+    val in = generate(12345678, List(0x01, 0x02, 0x03, 0x04, 0x7f), constSize(65535), badContent)
     val -\/("Incomplete or truncated input. (65535 bytes payload of packet 0.)") = MultiPacketDecoder.decode(ByteBuffer.wrap(in))
   }
 


### PR DESCRIPTION
Hopefully the last of the offline mode requests. This completes the integration with the mobile, allowing the iOS client to send the offline mode request in one block, and to also provide a mechanism for the client to indicate that it should move to offline mode if there is an inconsistency in the data.

Merging this PR will break the old serialized ``MultiPacket``s, and it changes the decoder to make it incompatible with the previous protocol.

The ``MultiPacket`` now includes ``timestamp: Long``, which represents time in milliseconds when the multipacket was constructed. The timestamp does not need to have any specific starting point (e.g. UNIX epoch), but it needs to be monotonously increasing with passing time for the duration of the session. On the server side, it is possible for the ``PacketWithLocation`` to contain zero-length ``BitVector``, which indicates that the sensor at the given location did not provide any data, even though it was expected.

* [x] Server replay haldler
* [x] iOS protocol change to handle timestamp and missing data
* [x] Server protocol change to handle timestamp and missing data