### PR TITLE
i8tn: Localized Strings

### DIFF
--- a/server/exercise/src/main/scala/com/eigengo/lift/exercise/UserExercisesClassifier.scala
+++ b/server/exercise/src/main/scala/com/eigengo/lift/exercise/UserExercisesClassifier.scala
@@ -1,6 +1,7 @@
 package com.eigengo.lift.exercise
 
 import akka.actor.{Props, Actor}
+import com.eigengo.lift.exercise.i8tn.Localized
 import com.eigengo.lift.exercise.UserExercisesClassifier._
 import scala.util.Random
 import UserExercises._
@@ -24,8 +25,8 @@ object UserExercisesClassifier {
     MuscleGroup(key = "legs",  title = "Legs",  exercises = List("squat", "leg press", "leg extension", "leg curl", "lunge")),
     MuscleGroup(key = "core",  title = "Core",  exercises = List("crunch", "side bend", "cable crunch", "sit up", "leg raises")),
     MuscleGroup(key = "back",  title = "Back",  exercises = List("pull up", "row", "deadlift", "hyper-extension")),
-    MuscleGroup(key = "arms",  title = "Arms",  exercises = List("bicep curl", "hammer curl", "pronated curl", "tricep push down", "tricep overhead extension", "tricep dip", "close-grip bench press")),
-    MuscleGroup(key = "chest", title = "Chest", exercises = List("chest press", "butterfly", "cable cross-over", "incline chest press", "push up")),
+    MuscleGroup(key = "arms",  title = Localized(_.exerciseArms),  exercises = List(Localized(_.exerciseArmsBicepCurl), "hammer curl", "pronated curl", "tricep push down", "tricep overhead extension", "tricep dip", "close-grip bench press")),
+    MuscleGroup(key = "chest", title = Localized(_.exerciseChest), exercises = List(Localized(_.exerciseChest), "butterfly", "cable cross-over", "incline chest press", "push up")),
     MuscleGroup(key = "shoulders", title = "Shoulders", exercises = List("shoulder press", "lateral raise", "front raise", "rear raise", "upright row", "shrug")),
     MuscleGroup(key = "cardiovascular", title = "Cardiovascular", exercises = List("running", "cycling", "swimming", "elliptical", "rowing"))
   )
@@ -98,7 +99,7 @@ class UserExercisesClassifier extends Actor {
         }
       sender() ! randomExercise(sessionProps)
     case ClassificationExamples(sessionProps) ⇒
-      sender() ! List(Exercise("chest press", Some(1.0), Some(Metric(80.0, Mass.Kilogram))), Exercise("foobar", Some(1.0), Some(Metric(50.0, Distance.Kilometre))), Exercise("barfoo", Some(1.0), Some(Metric(10.0, Distance.Kilometre))))
+      sender() ! List(Exercise(Localized(_.exerciseChestChestPress), Some(1.0), Some(Metric(80.0, Mass.Kilogram))), Exercise(Localized(_.exerciseArmsBicepCurl), Some(1.0), Some(Metric(50.0, Distance.Kilometre))), Exercise("barfoo", Some(1.0), Some(Metric(10.0, Distance.Kilometre))))
   }
 
 }

--- a/server/exercise/src/main/scala/com/eigengo/lift/exercise/UserExercisesClassifier.scala
+++ b/server/exercise/src/main/scala/com/eigengo/lift/exercise/UserExercisesClassifier.scala
@@ -22,13 +22,50 @@ object UserExercisesClassifier {
   case class MuscleGroup(key: String, title: String, exercises: List[String])
 
   val supportedMuscleGroups = List(
-    MuscleGroup(key = "legs",  title = "Legs",  exercises = List("squat", "leg press", "leg extension", "leg curl", "lunge")),
-    MuscleGroup(key = "core",  title = "Core",  exercises = List("crunch", "side bend", "cable crunch", "sit up", "leg raises")),
-    MuscleGroup(key = "back",  title = "Back",  exercises = List("pull up", "row", "deadlift", "hyper-extension")),
-    MuscleGroup(key = "arms",  title = Localized(_.exerciseArms),  exercises = List(Localized(_.exerciseArmsBicepCurl), "hammer curl", "pronated curl", "tricep push down", "tricep overhead extension", "tricep dip", "close-grip bench press")),
-    MuscleGroup(key = "chest", title = Localized(_.exerciseChest), exercises = List(Localized(_.exerciseChest), "butterfly", "cable cross-over", "incline chest press", "push up")),
-    MuscleGroup(key = "shoulders", title = "Shoulders", exercises = List("shoulder press", "lateral raise", "front raise", "rear raise", "upright row", "shrug")),
-    MuscleGroup(key = "cardiovascular", title = "Cardiovascular", exercises = List("running", "cycling", "swimming", "elliptical", "rowing"))
+    MuscleGroup(key = "legs",  title = Localized(_.exerciseLegs),  exercises = List(
+      Localized(_.exerciseLegsSquat),
+      Localized(_.exerciseLegsLegPress),
+      Localized(_.exerciseLegsLegExtension),
+      Localized(_.exerciseLegsLegCurl),
+      Localized(_.exerciseLegsLunge))),
+    MuscleGroup(key = "core",  title = Localized(_.exerciseCore),  exercises = List(
+      Localized(_.exerciseCoreCrunch),
+      Localized(_.exerciseCoreSideBend),
+      Localized(_.exerciseCoreCableCrunch),
+      Localized(_.exerciseCoreSitup),
+      Localized(_.exerciseCoreLegRaises))),
+    MuscleGroup(key = "back",  title = Localized(_.exerciseBack),  exercises = List(
+      Localized(_.exerciseBackPullup),
+      Localized(_.exeriseBackRow),
+      Localized(_.exerciseBackDeadlift),
+      Localized(_.exerciseBackHyperExtension))),
+    MuscleGroup(key = "arms",  title = Localized(_.exerciseArms),  exercises = List(
+      Localized(_.exerciseArmsBicepCurl),
+      Localized(_.exerciseArmsHammerCurl),
+      Localized(_.exerciseArmsPronatedCurl),
+      Localized(_.exericseArmsTricepPushdown),
+      Localized(_.exerciseArmsTricepOverheadExtension),
+      Localized(_.exerciseArmsDip),
+      Localized(_.exerciseArmsCloseGripBenchPress))),
+    MuscleGroup(key = "chest", title = Localized(_.exerciseChest), exercises = List(
+      Localized(_.exerciseChest),
+      Localized(_.exerciseChestButterfly),
+      Localized(_.exerciseChestCableCrossover),
+      Localized(_.exerciseChestInclinePress),
+      Localized(_.exerciseChestPushup))),
+    MuscleGroup(key = "shoulders", title = Localized(_.exerciseShoulders), exercises = List(
+      Localized(_.exerciseShouldersShoulderPress),
+      Localized(_.exerciseShouldersLateralRaise),
+      Localized(_.exerciseShouldersFrontRaise),
+      Localized(_.exerciseShouldersRearRaise),
+      Localized(_.exerciseShouldersUprightRow),
+      Localized(_.exerciseShouldersShrug))),
+    MuscleGroup(key = "cardiovascular", title = Localized(_.exerciseCardio), exercises = List(
+      Localized(_.exerciseCardioRunning),
+      Localized(_.exerciseCardioCycling),
+      Localized(_.exerciseCardioSwimming),
+      Localized(_.exerciseCardioElliptical),
+      Localized(_.exerciseCardioRowing)))
   )
 
   /**

--- a/server/exercise/src/main/scala/i8tn.scala
+++ b/server/exercise/src/main/scala/i8tn.scala
@@ -81,7 +81,7 @@ trait i8tn {
   def exerciseCardioRowing: String
 }
 
-object English extends i8tn {
+object en_GB extends i8tn {
   val appName = "Lift"
   val okCaption = "OK"
 
@@ -160,7 +160,7 @@ object English extends i8tn {
 }
 
 object Localized {
-  @volatile private var currenti8tn: i8tn = English
+  @volatile private var currenti8tn: i8tn = en_GB
 
   def apply(f: i8tn ⇒ String): String = f(currenti8tn)
 

--- a/server/exercise/src/main/scala/i8tn.scala
+++ b/server/exercise/src/main/scala/i8tn.scala
@@ -1,0 +1,51 @@
+package com.eigengo.lift.exercise.i8tn
+
+/**
+ * Created by charlesrice on 26/01/15.
+ */
+
+trait i8tn {
+  def appName: String
+  def okCaption: String
+
+  /**
+   * Arms localization
+   * @return
+   */
+  def exerciseArms: String
+  def exerciseArmsBicepCurl: String
+
+  /**
+   * Chest localization
+   */
+  def exerciseChest: String
+  def exerciseChestChestPress: String
+
+}
+
+object English extends i8tn {
+  val appName = "Lift"
+  val okCaption = "OK"
+
+  /**
+   * Arms localization
+   */
+  val exerciseArms = "Arms"
+  val exerciseArmsBicepCurl = "Bicep curl"
+
+  /**
+   * Chest localization
+   */
+  val exerciseChest = "Chest"
+  val exerciseChestChestPress = "Chest press"
+
+}
+
+object Localized {
+  @volatile private var currenti8tn: i8tn = English
+
+  def apply(f: i8tn ⇒ String): String = f(currenti8tn)
+
+  def setLanguage(l: i8tn): Unit = (currenti8tn = l)
+
+}

--- a/server/exercise/src/main/scala/i8tn.scala
+++ b/server/exercise/src/main/scala/i8tn.scala
@@ -15,8 +15,10 @@ trait i8tn {
   def exerciseArmsBicepCurl: String
   def exerciseArmsHammerCurl: String
   def exerciseArmsPronatedCurl: String
+  def exerciseArmsDip: String
   def exericseArmsTricepPushdown: String
   def exerciseArmsTricepOverheadExtension: String
+  def exerciseArmsCloseGripBenchPress: String
 
   /**
    * Back localization
@@ -50,6 +52,7 @@ trait i8tn {
   /**
    * Legs localization
    */
+  def exerciseLegs: String
   def exerciseLegsSquat: String
   def exerciseLegsLegPress: String
   def exerciseLegsLegExtension: String
@@ -89,8 +92,10 @@ object English extends i8tn {
   val exerciseArmsBicepCurl = "Bicep curl"
   val exerciseArmsHammerCurl = "Hammer curl"
   val exerciseArmsPronatedCurl = "Pronated curl"
+  val exerciseArmsDip = "Dip"
   val exericseArmsTricepPushdown = "Tricep push down"
   val exerciseArmsTricepOverheadExtension = "Tricep overhead extension"
+  val exerciseArmsCloseGripBenchPress = "Close-grip bench press"
 
   /**
    * Back localization
@@ -124,6 +129,7 @@ object English extends i8tn {
   /**
    * Legs localization
    */
+  val exerciseLegs = "Legs"
   val exerciseLegsSquat = "Squat"
   val exerciseLegsLegPress = "Leg press"
   val exerciseLegsLegExtension = "Leg extension"

--- a/server/exercise/src/main/scala/i8tn.scala
+++ b/server/exercise/src/main/scala/i8tn.scala
@@ -10,17 +10,72 @@ trait i8tn {
 
   /**
    * Arms localization
-   * @return
    */
   def exerciseArms: String
   def exerciseArmsBicepCurl: String
+  def exerciseArmsHammerCurl: String
+  def exerciseArmsPronatedCurl: String
+  def exericseArmsTricepPushdown: String
+  def exerciseArmsTricepOverheadExtension: String
+
+  /**
+   * Back localization
+   */
+  def exerciseBack: String
+  def exerciseBackDeadlift: String
+  def exerciseBackPullup: String
+  def exeriseBackRow: String
+  def exerciseBackHyperExtension: String
 
   /**
    * Chest localization
    */
   def exerciseChest: String
   def exerciseChestChestPress: String
+  def exerciseChestButterfly: String
+  def exerciseChestCableCrossover: String
+  def exerciseChestInclinePress: String
+  def exerciseChestPushup: String
 
+  /**
+   * Core localization
+   */
+  def exerciseCore: String
+  def exerciseCoreCrunch: String
+  def exerciseCoreSideBend: String
+  def exerciseCoreCableCrunch: String
+  def exerciseCoreSitup: String
+  def exerciseCoreLegRaises: String
+
+  /**
+   * Legs localization
+   */
+  def exerciseLegsSquat: String
+  def exerciseLegsLegPress: String
+  def exerciseLegsLegExtension: String
+  def exerciseLegsLegCurl: String
+  def exerciseLegsLunge: String
+
+  /**
+   * Shoulders localization
+   */
+  def exerciseShoulders: String
+  def exerciseShouldersShoulderPress: String
+  def exerciseShouldersLateralRaise: String
+  def exerciseShouldersFrontRaise: String
+  def exerciseShouldersRearRaise: String
+  def exerciseShouldersUprightRow: String
+  def exerciseShouldersShrug: String
+
+  /**
+   * Cardiovascular localization
+   */
+  def exerciseCardio: String
+  def exerciseCardioRunning: String
+  def exerciseCardioCycling: String
+  def exerciseCardioSwimming: String
+  def exerciseCardioElliptical: String
+  def exerciseCardioRowing: String
 }
 
 object English extends i8tn {
@@ -32,12 +87,69 @@ object English extends i8tn {
    */
   val exerciseArms = "Arms"
   val exerciseArmsBicepCurl = "Bicep curl"
+  val exerciseArmsHammerCurl = "Hammer curl"
+  val exerciseArmsPronatedCurl = "Pronated curl"
+  val exericseArmsTricepPushdown = "Tricep push down"
+  val exerciseArmsTricepOverheadExtension = "Tricep overhead extension"
+
+  /**
+   * Back localization
+   */
+  val exerciseBack = "Back"
+  val exerciseBackDeadlift = "Deadlift"
+  val exerciseBackPullup = "Pull up"
+  val exeriseBackRow = "Row"
+  val exerciseBackHyperExtension = "Hyper-extension"
 
   /**
    * Chest localization
    */
   val exerciseChest = "Chest"
   val exerciseChestChestPress = "Chest press"
+  val exerciseChestButterfly = "Butterfly"
+  val exerciseChestCableCrossover = "Cable crossover"
+  val exerciseChestInclinePress = "Incline chest press"
+  val exerciseChestPushup = "Push up"
+
+  /**
+   * Core localization
+   */
+  val exerciseCore = "Core"
+  val exerciseCoreCrunch = "Crunch"
+  val exerciseCoreSideBend = "Side bend"
+  val exerciseCoreCableCrunch = "Cable crunch"
+  val exerciseCoreSitup = "Sit up"
+  val exerciseCoreLegRaises = "Leg raises"
+
+  /**
+   * Legs localization
+   */
+  val exerciseLegsSquat = "Squat"
+  val exerciseLegsLegPress = "Leg press"
+  val exerciseLegsLegExtension = "Leg extension"
+  val exerciseLegsLegCurl = "Leg curl"
+  val exerciseLegsLunge = "Lunge"
+
+  /**
+   * Shoulders localization
+   */
+  val exerciseShoulders = "Shoulders"
+  val exerciseShouldersShoulderPress = "Shoulder press"
+  val exerciseShouldersLateralRaise = "Lateral raise"
+  val exerciseShouldersFrontRaise = "Front raise"
+  val exerciseShouldersRearRaise = "Rear raise"
+  val exerciseShouldersUprightRow = "Upright row"
+  val exerciseShouldersShrug = "Shrug"
+
+  /**
+   * Cardiovascular localization
+   */
+  val exerciseCardio = "Cardiovascular"
+  val exerciseCardioRunning = "Running"
+  val exerciseCardioCycling = "Cycling"
+  val exerciseCardioSwimming = "Swimming"
+  val exerciseCardioElliptical = "Elliptical"
+  val exerciseCardioRowing = "Rowing"
 
 }
 


### PR DESCRIPTION
Mentioned in issue #43 there is a localization schema in iOS that needs to be mimicked in the server code, limiting use of hard-coded strings.

- [x] Make the localization object
- [x] Create the exercise strings
- [x] Replace hard-coding with `Localized` strings
- [ ] Hunt down any extra strings