### PR TITLE
Sketching out the ExerciseModel

### DIFF
--- a/server/exercise/src/main/R/chart.R
+++ b/server/exercise/src/main/R/chart.R
@@ -1,4 +1,4 @@
-data <- scale(read.csv("/Users/janmachacek/x.csv", col.names=c('x', 'y', 'z')))
+data <- scale(read.csv(paste(path.expand("~"), "/x.csv", sep=""), col.names=c('x', 'y', 'z')))
 data.ts <- ts(data)
 
 plot(data.ts)

--- a/server/exercise/src/main/scala/com/eigengo/lift/exercise/ExerciseService.scala
+++ b/server/exercise/src/main/scala/com/eigengo/lift/exercise/ExerciseService.scala
@@ -40,7 +40,7 @@ trait ExerciseService extends Directives with ExerciseMarshallers {
     } ~
     path("exercise" / UserIdValue / "start") { userId ⇒
       post {
-        handleWith { sessionProps: SessionProps ⇒
+        handleWith { sessionProps: SessionProperties ⇒
           (userExercises ? UserExerciseSessionStart(userId, sessionProps)).mapRight[UUID]
         }
       }
@@ -79,7 +79,7 @@ trait ExerciseService extends Directives with ExerciseMarshallers {
     } ~
     path("exercise" / UserIdValue / SessionIdValue / "replay") { (userId, sessionId) ⇒
       post {
-        handleWith { sessionProps: SessionProps ⇒
+        handleWith { sessionProps: SessionProperties ⇒
           (userExercises ? UserExerciseSessionReplayStart(userId, sessionId, sessionProps)).mapRight[UUID]
         }
       } ~

--- a/server/exercise/src/main/scala/com/eigengo/lift/exercise/SessionProperties.scala
+++ b/server/exercise/src/main/scala/com/eigengo/lift/exercise/SessionProperties.scala
@@ -21,7 +21,7 @@ object SessionId {
  * @param muscleGroupKeys the planned muscle groups
  * @param intendedIntensity the planned intensity
  */
-case class SessionProps(startDate: Date,
+case class SessionProperties(startDate: Date,
                    muscleGroupKeys: Seq[MuscleGroupKey],
                    intendedIntensity: ExerciseIntensity) {
   require(intendedIntensity >  0.0, "intendedIntensity must be between <0, 1)")

--- a/server/exercise/src/main/scala/com/eigengo/lift/exercise/UserExercises.scala
+++ b/server/exercise/src/main/scala/com/eigengo/lift/exercise/UserExercises.scala
@@ -29,14 +29,14 @@ object UserExercises {
    * @param sessionProps the session
    * @param sensorData the sensor data
    */
-  case class ClassifyExerciseEvt[D <: SensorData](sessionProps: SessionProps, sensorData: List[SensorDataWithLocation[D]])
+  case class ClassifyExerciseEvt[D <: SensorData](sessionProps: SessionProperties, sensorData: List[SensorDataWithLocation[D]])
 
   /**
    * The session has started
    * @param sessionId the session identity
    * @param sessionProps the session props
    */
-  case class SessionStartedEvt(sessionId: SessionId, sessionProps: SessionProps)
+  case class SessionStartedEvt(sessionId: SessionId, sessionProps: SessionProperties)
 
   /**
    * The session has been abandoned. Typically, the mobile application has detected a loss of

--- a/server/exercise/src/main/scala/com/eigengo/lift/exercise/UserExercisesClassifier.scala
+++ b/server/exercise/src/main/scala/com/eigengo/lift/exercise/UserExercisesClassifier.scala
@@ -2,7 +2,8 @@ package com.eigengo.lift.exercise
 
 import akka.actor.{Props, Actor}
 import com.eigengo.lift.exercise.UserExercisesClassifier._
-import scala.util.Random
+import com.eigengo.lift.exercise.classifiers.model.RandomExerciseModel
+import com.eigengo.lift.exercise.classifiers.ExerciseModel
 import UserExercises._
 
 /**
@@ -34,7 +35,7 @@ object UserExercisesClassifier {
    * Provides List[Exercise] as examples of exercises for the given ``sessionProps``
    * @param sessionProps the session props
    */
-  case class ClassificationExamples(sessionProps: SessionProps)
+  case class ClassificationExamples(sessionProps: SessionProperties)
   
   /**
    * ADT holding the classification result
@@ -68,35 +69,17 @@ object UserExercisesClassifier {
 }
 
 /**
- * Match the received exercise data using the given model
+ * Match the received exercise data using the given model. By default, a random exercise model is used.
  */
-class UserExercisesClassifier extends Actor {
-  val exercises =
-    Map(
-      "arms" → List("Biceps curl", "Triceps press"),
-      "chest" → List("Chest press", "Butterfly", "Cable cross-over")
-    )
-  val metadata = ModelMetadata(2)
+class UserExercisesClassifier(model: ExerciseModel = RandomExerciseModel) extends Actor {
 
-  private def randomExercise(sessionProps: SessionProps): ClassifiedExercise = {
-    val mgk = Random.shuffle(sessionProps.muscleGroupKeys).head
-    exercises.get(mgk).fold[ClassifiedExercise](UnclassifiedExercise(metadata))(es ⇒ FullyClassifiedExercise(metadata, 1.0, Exercise(Random.shuffle(es).head, None, None)))
-  }
+  import ExerciseModel._
 
   override def receive: Receive = {
-    case ClassifyExerciseEvt(sessionProps, sdwls) =>
-      sdwls.foreach { sdwl ⇒ sdwl.data}
-        sdwls.foreach { sdwl ⇒
+    case event @ ClassifyExerciseEvt(sessionProps, _) =>
+      model.update(event)
+      model.query(True(sessionProps), sender())
 
-          sdwl.data.foreach {
-            case AccelerometerData(sr, values) ⇒
-              val xs = values.map(_.x)
-              val ys = values.map(_.y)
-              val zs = values.map(_.z)
-              println(s"****** X: (${xs.min}, ${xs.max}), Y: (${ys.min}, ${ys.max}), Z: (${zs.min}, ${zs.max})")
-          }
-        }
-      sender() ! randomExercise(sessionProps)
     case ClassificationExamples(sessionProps) ⇒
       sender() ! List(Exercise("chest press", Some(1.0), Some(Metric(80.0, Mass.Kilogram))), Exercise("foobar", Some(1.0), Some(Metric(50.0, Distance.Kilometre))), Exercise("barfoo", Some(1.0), Some(Metric(10.0, Distance.Kilometre))))
   }

--- a/server/exercise/src/main/scala/com/eigengo/lift/exercise/UserExercisesClassifier.scala
+++ b/server/exercise/src/main/scala/com/eigengo/lift/exercise/UserExercisesClassifier.scala
@@ -10,7 +10,8 @@ import UserExercises._
  * Companion object for the classifier
  */
 object UserExercisesClassifier {
-  val props: Props = Props[UserExercisesClassifier]
+  // By default, we configure exercise classification iwth a random model
+  val props: Props = Props(new UserExercisesClassifier(RandomExerciseModel))
 
   /**
    * Muscle group information
@@ -69,9 +70,9 @@ object UserExercisesClassifier {
 }
 
 /**
- * Match the received exercise data using the given model. By default, a random exercise model is used.
+ * Match the received exercise data using the given model.
  */
-class UserExercisesClassifier(model: ExerciseModel = RandomExerciseModel) extends Actor {
+class UserExercisesClassifier(model: ExerciseModel) extends Actor {
 
   import ExerciseModel._
 

--- a/server/exercise/src/main/scala/com/eigengo/lift/exercise/UserExercisesProcessor.scala
+++ b/server/exercise/src/main/scala/com/eigengo/lift/exercise/UserExercisesProcessor.scala
@@ -48,7 +48,7 @@ object UserExercisesProcessor {
    * @param sessionId the session identity
    * @param sessionProps the session props
    */
-  case class UserExerciseSessionReplayStart(userId: UserId, sessionId: SessionId, sessionProps: SessionProps)
+  case class UserExerciseSessionReplayStart(userId: UserId, sessionId: SessionId, sessionProps: SessionProperties)
 
   /**
    * User classified exercise start.
@@ -147,7 +147,7 @@ object UserExercisesProcessor {
    * @param sessionId the session identity
    * @param sessionProps the session props
    */
-  private case class ExerciseSessionReplayStart(sessionId: SessionId, sessionProps: SessionProps)
+  private case class ExerciseSessionReplayStart(sessionId: SessionId, sessionProps: SessionProperties)
 
   /**
    * Sets the metric for the unmarked exercises in the currently open set
@@ -173,7 +173,7 @@ object UserExercisesProcessor {
    * @param userId the user identity
    * @param sessionProps the sessionProps details
    */
-  case class UserExerciseSessionStart(userId: UserId, sessionProps: SessionProps)
+  case class UserExerciseSessionStart(userId: UserId, sessionProps: SessionProperties)
 
   /**
    * Ends the user exercise sessionProps
@@ -186,7 +186,7 @@ object UserExercisesProcessor {
    * The sessionProps has started
    * @param sessionProps the sessionProps identity
    */
-  private case class ExerciseSessionStart(sessionProps: SessionProps)
+  private case class ExerciseSessionStart(sessionProps: SessionProperties)
 
   /**
    * The sessionProps has ended
@@ -293,7 +293,7 @@ import scala.concurrent.duration._
       context.become(exercising(sessionId, sessionProps))
   }
 
-  private def replaying(oldSessionId: SessionId, newSessionId: SessionId, sessionProps: SessionProps): Receive = withPassivation {
+  private def replaying(oldSessionId: SessionId, newSessionId: SessionId, sessionProps: SessionProperties): Receive = withPassivation {
     case ExerciseSessionReplayStart(_, _) ⇒
       sender() ! \/.left("Another session replay in progress")
 
@@ -313,7 +313,7 @@ import scala.concurrent.duration._
       }
   }
 
-  private def exercising(id: SessionId, sessionProps: SessionProps): Receive = withPassivation {
+  private def exercising(id: SessionId, sessionProps: SessionProperties): Receive = withPassivation {
     // start and end
     case ExerciseSessionStart(newSessionProps) ⇒
       val newId = SessionId.randomId()

--- a/server/exercise/src/main/scala/com/eigengo/lift/exercise/UserExercisesSessions.scala
+++ b/server/exercise/src/main/scala/com/eigengo/lift/exercise/UserExercisesSessions.scala
@@ -55,7 +55,7 @@ object UserExercisesSessions {
    * @param sessionProps the session props
    * @param sets the exercise sets done
    */
-  case class ExerciseSession(id: SessionId, sessionProps: SessionProps, sets: List[ExerciseSet]) {
+  case class ExerciseSession(id: SessionId, sessionProps: SessionProperties, sets: List[ExerciseSet]) {
     def withNewExerciseSet(set: ExerciseSet): ExerciseSession = {
       if (set.isEmpty) this else copy(sets = sets :+ set)
     }
@@ -69,7 +69,7 @@ object UserExercisesSessions {
    * @param sessionProps the session props
    * @param setIntensities the averaged set intensities
    */
-  case class SessionSummary(id: SessionId, sessionProps: SessionProps, setIntensities: Array[Double])
+  case class SessionSummary(id: SessionId, sessionProps: SessionProperties, setIntensities: Array[Double])
 
   /**
    * Session itensity summary. Compares actual and planned intensitites.

--- a/server/exercise/src/main/scala/com/eigengo/lift/exercise/classifiers/ExerciseModel.scala
+++ b/server/exercise/src/main/scala/com/eigengo/lift/exercise/classifiers/ExerciseModel.scala
@@ -1,3 +1,50 @@
 package com.eigengo.lift.exercise.classifiers
 
-case class ExerciseModel(name: String)
+import akka.actor.ActorRef
+import com.eigengo.lift.exercise.UserExercises.ClassifyExerciseEvt
+import com.eigengo.lift.exercise.{SensorData, SessionProperties}
+
+object ExerciseModel {
+
+  /**
+   * Language used to query exercise models with
+   */
+  sealed trait Query {
+    def session: SessionProperties
+  }
+
+  /**
+   * Query that always succeeds
+   */
+  case class True(session: SessionProperties) extends Query
+
+}
+
+/**
+ * Model interface trait. Implementations of this trait define specific exercising models that may be updated and queried.
+ */
+trait ExerciseModel {
+
+  import ExerciseModel._
+
+  /**
+   * Unique name for exercise model
+   */
+  def name: String
+
+  /**
+   * Updates the model by adding in new sensor event data.
+   *
+   * @param event newly received sensor event data
+   */
+  def update[A <: SensorData](event: ClassifyExerciseEvt[A]): Unit
+
+  /**
+   * Queries the model. Query result is sent (as a message) to `listener`.
+   *
+   * @param formula  formula defining the query
+   * @param listener Actor that will receive model query result
+   */
+  def query(formula: Query, listener: ActorRef): Unit
+
+}

--- a/server/exercise/src/main/scala/com/eigengo/lift/exercise/classifiers/RepetitionExtractor.scala
+++ b/server/exercise/src/main/scala/com/eigengo/lift/exercise/classifiers/RepetitionExtractor.scala
@@ -185,7 +185,7 @@ trait RepetitionExtractor {
   private def saveCsv[A](name: String, values: Iterable[A])(f: A ⇒ String): Unit = {
     import scala.language.reflectiveCalls
 
-    val os = new FileOutputStream(s"/Users/janmachacek/$name.csv")
+    val os = new FileOutputStream(s"${System.getProperty("user.home")}/$name.csv")
     values.iterator.foreach { case x ⇒
       val l = s"${f(x)}\n"
       os.write(l.getBytes("UTF-8"))

--- a/server/exercise/src/main/scala/com/eigengo/lift/exercise/classifiers/model/RandomExerciseModel.scala
+++ b/server/exercise/src/main/scala/com/eigengo/lift/exercise/classifiers/model/RandomExerciseModel.scala
@@ -1,0 +1,50 @@
+package com.eigengo.lift.exercise.classifiers.model
+
+import akka.actor.ActorRef
+import com.eigengo.lift.exercise.classifiers.ExerciseModel
+import com.eigengo.lift.exercise._
+import com.eigengo.lift.exercise.UserExercises.{ClassifyExerciseEvt, ModelMetadata}
+import com.eigengo.lift.exercise.UserExercisesClassifier.{FullyClassifiedExercise, UnclassifiedExercise, ClassifiedExercise}
+import scala.util.Random
+
+/**
+ * Random exercising model. Updates are simply printed out and queries always succeed (by sending a random message to
+ * the listening actor).
+ */
+object RandomExerciseModel extends ExerciseModel {
+
+  import ExerciseModel._
+
+  val name = "random"
+
+  private val exercises =
+    Map(
+      "arms" → List("Biceps curl", "Triceps press"),
+      "chest" → List("Chest press", "Butterfly", "Cable cross-over")
+    )
+  private val metadata = ModelMetadata(2)
+
+  private def randomExercise(sessionProps: SessionProperties): ClassifiedExercise = {
+    val mgk = Random.shuffle(sessionProps.muscleGroupKeys).head
+    exercises.get(mgk).fold[ClassifiedExercise](UnclassifiedExercise(metadata))(es ⇒ FullyClassifiedExercise(metadata, 1.0, Exercise(Random.shuffle(es).head, None, None)))
+  }
+
+  // No update occurs here, we simply print out a summary of the received data
+  def update[A <: SensorData](sdwls: ClassifyExerciseEvt[A]) = {
+    sdwls.sensorData.foreach { sdwl =>
+      sdwl.data.foreach {
+        case AccelerometerData(sr, values) =>
+          val xs = values.map(_.x)
+          val ys = values.map(_.y)
+          val zs = values.map(_.z)
+          println(s"****** X: (${xs.min}, ${xs.max}), Y: (${ys.min}, ${ys.max}), Z: (${zs.min}, ${zs.max})")
+      }
+    }
+  }
+
+  // We only expect `true` queries here
+  def query(query: Query, listener: ActorRef) = {
+    listener ! randomExercise(query.session)
+  }
+
+}

--- a/server/exercise/src/test/scala/com/eigengo/lift/exercise/ExerciseServiceTest.scala
+++ b/server/exercise/src/test/scala/com/eigengo/lift/exercise/ExerciseServiceTest.scala
@@ -27,7 +27,7 @@ object ExerciseServiceTest {
     val intensity = Some(1.0)
     val startDate = dateFormat.parse("1970-01-01")
     val endDate = dateFormat.parse("1970-01-01")
-    val sessionProps = SessionProps(startDate, Seq("Legs"), 1.0)
+    val sessionProps = SessionProperties(startDate, Seq("Legs"), 1.0)
     val muscleGroups = List(MuscleGroup("legs", "Legs", List("squat")))
     val sessionSummary = List(SessionSummary(sessionId, sessionProps, Array(1.0)))
     val session = Some(ExerciseSession(sessionId, sessionProps, List(ExerciseSet(List(squat)))))

--- a/server/exercise/src/test/scala/com/eigengo/lift/exercise/UserExercisesTracingTest.scala
+++ b/server/exercise/src/test/scala/com/eigengo/lift/exercise/UserExercisesTracingTest.scala
@@ -15,7 +15,7 @@ class UserExercisesTracingTest extends FlatSpec with TestKitBase with Matchers w
 
   "The session events" should "be saved" in {
     val id = SessionId.randomId()
-    val props = SessionProps(new Date(), Seq(), 1.0)
+    val props = SessionProperties(new Date(), Seq(), 1.0)
     val ad = AccelerometerData(100, List(AccelerometerValue(1, 3, 4)))
     val sdwl = SensorDataWithLocation(SensorDataSourceLocationAny, List(ad))
 


### PR DESCRIPTION
* [x] exercise model interface defined with updating and querying
* [x] random exercise code refactored into a model
* [x] simple query DSL defined (to be expanded in future PRs)
* [x] `sbt test` passes
* [x] ready for review/merge

---
This PR also renames `SessionProps` to avoid any potential confusion.

Future PRs will develop the model querying and define a model that integrates the Akka streaming classification code.