### PR TITLE
Changed use of APP_HOST to HOST for production

### DIFF
--- a/server/main/src/main/resources/production.conf
+++ b/server/main/src/main/resources/production.conf
@@ -5,7 +5,7 @@ akka {
 
   remote {
     netty.tcp {
-      hostname = ${?APP_ADDR}
+      hostname = ${?HOST} # NOTE: a Marathon enforced change (elsewhere we use APP_ADDR)
       port = ${?APP_PORT}
     }
   }


### PR DESCRIPTION
Production currently uses Marathon for deployment. Unfortunately, it appears that it restricts one to use HOST to specify the IP address/hostname and is otherwise unable to copy this value into other environment variables.