### PR TITLE
Patch to ensure environment lists are correctly handled by Lift

### DIFF
--- a/server/main/src/main/resources/production.conf
+++ b/server/main/src/main/resources/production.conf
@@ -15,7 +15,7 @@ akka {
   }
 
   cluster {
-    seed-nodes = [ ${?SEED_NODES} ]
+    seed-nodes = ${?SEED_NODES} # NOTE: will be treated as a comma separated string list by Lift main
     retry = 10s
     min-nr-of-members = 2
   }
@@ -27,11 +27,11 @@ akka {
 }
 
 cassandra-journal {
-  contact-points = [ ${?JOURNAL} ]
+  contact-points = ${?JOURNAL} # NOTE: will be treated as a comma separated string list by Lift main
 }
 
 cassandra-snapshot-store {
-  contact-points = [ ${?SNAPSHOT} ]
+  contact-points = ${?SNAPSHOT} # NOTE: will be treated as a comma separated string list by Lift main
 }
 
 kafka {

--- a/server/main/src/main/scala/com/eigengo/lift/LiftContainerApp.scala
+++ b/server/main/src/main/scala/com/eigengo/lift/LiftContainerApp.scala
@@ -1,6 +1,7 @@
 package com.eigengo.lift
 
 import akka.actor.{ActorPath, ActorSystem}
+import com.eigengo.lift.common.MicroserviceApp.MicroserviceProps
 import com.typesafe.config.ConfigFactory
 
 /**
@@ -10,11 +11,27 @@ import com.typesafe.config.ConfigFactory
 object LiftContainerApp extends App with LocalAppUtil {
 
   // In production, Akka and REST port numbers are obtained from environment variables in production.conf
-  val config = ConfigFactory.load("production.conf")
-  val akkaPort = config.getInt("akka.remote.netty.tcp.port")
-  val httpPort = config.getInt("akka.rest.port")
+  val rawConfig = ConfigFactory.load("production.conf")
+  val akkaPort = rawConfig.getInt("akka.remote.netty.tcp.port")
+  val httpPort = rawConfig.getInt("akka.rest.port")
+
+  val microserviceProps = MicroserviceProps("Lift")
+  val clusterShardingConfig = ConfigFactory.parseString(s"akka.contrib.cluster.sharding.role=${microserviceProps.role}")
+  val clusterRoleConfig = ConfigFactory.parseString(s"akka.cluster.roles=[${microserviceProps.role}]")
+  // As the following configuration values are lists supplied by environment variables, we need to work a little harder here to ensure they are parsed correctly
+  val seedingConfig = ConfigFactory.parseString(s"akka.cluster.seed-nodes=[${rawConfig.getString("akka.cluster.seed-nodes").split(",").map(_.trim).mkString("\"", "\",\"", "\"")}]")
+  val journalConfig = ConfigFactory.parseString(s"cassandra-journal.contact-points=[${rawConfig.getString("cassandra-journal.contact-points").split(",").map(_.trim).mkString("\"", "\",\"", "\"")}]")
+  val snapshotConfig = ConfigFactory.parseString(s"cassandra-snapshot-store.contact-points=[${rawConfig.getString("cassandra-snapshot-store.contact-points").split(",").map(_.trim).mkString("\"", "\",\"", "\"")}]")
+
+  val config = ConfigFactory.parseString(s"akka.remote.netty.tcp.port=$akkaPort")
+    .withFallback(seedingConfig)
+    .withFallback(journalConfig)
+    .withFallback(snapshotConfig)
+    .withFallback(clusterShardingConfig)
+    .withFallback(clusterRoleConfig)
+    .withFallback(ConfigFactory.load("production.conf"))
 
   // In production, journal and snapshot stores are cassandra based - so setup is configuration/deployment based and so there is no work to do here!
-  actorSystemStartUp(akkaPort, httpPort, "production.conf", { (ActorSystem, Boolean, ActorPath) => })
+  actorSystemStartUp(akkaPort, httpPort, config, { (ActorSystem, Boolean, ActorPath) => })
 
 }

--- a/server/main/src/main/scala/com/eigengo/lift/LocalAppUtil.scala
+++ b/server/main/src/main/scala/com/eigengo/lift/LocalAppUtil.scala
@@ -2,12 +2,11 @@ package com.eigengo.lift
 
 import akka.actor.{ActorPath, Props, ActorSystem}
 import akka.io.IO
-import com.eigengo.lift.common.MicroserviceApp.MicroserviceProps
 import com.eigengo.lift.exercise.ExerciseBoot
 import com.eigengo.lift.kafka.KafkaBoot
 import com.eigengo.lift.notification.NotificationBoot
 import com.eigengo.lift.profile.ProfileBoot
-import com.typesafe.config.ConfigFactory
+import com.typesafe.config.Config
 import spray.can.Http
 import spray.routing._
 
@@ -15,13 +14,9 @@ trait LocalAppUtil {
 
   val LiftActorSystem = "Lift"
 
-  def actorSystemStartUp(port: Int, restPort: Int, configFile: String, journalStartUp: (ActorSystem, Boolean, ActorPath) => Unit): Unit = {
+  def actorSystemStartUp(port: Int, restPort: Int, config: Config, journalStartUp: (ActorSystem, Boolean, ActorPath) => Unit): Unit = {
     import scala.collection.JavaConverters._
     // Override the configuration of the port
-    val microserviceProps = MicroserviceProps("Lift")
-    val clusterShardingConfig = ConfigFactory.parseString(s"akka.contrib.cluster.sharding.role=${microserviceProps.role}")
-    val clusterRoleConfig = ConfigFactory.parseString(s"akka.cluster.roles=[${microserviceProps.role}]")
-    val config = ConfigFactory.parseString(s"akka.remote.netty.tcp.port=$port").withFallback(clusterShardingConfig).withFallback(clusterRoleConfig).withFallback(ConfigFactory.load(configFile))
     val firstSeedNodePort = (for {
       seedNode ← config.getStringList("akka.cluster.seed-nodes").asScala
       port ← ActorPath.fromString(seedNode).address.port


### PR DESCRIPTION
* [x] modified Lift main so that: config string lists (configured via environment variables) are parsed and correctly formatted
* [x] `sbt test`
* [x] ready for review/merge

---
This PR aims at closing https://github.com/eigengo/lift/issues/90