### PR TITLE
Cleanup pebble-ios communication

### DIFF
--- a/ios/Lift/Device/SensorData.swift
+++ b/ios/Lift/Device/SensorData.swift
@@ -321,7 +321,7 @@ class SensorDataArray {
             let currentStart = data.startTime
             let lastEnd = last.endTime(header.sampleSize, samplesPerSecond: header.samplesPerSecond)
             if currentStart < lastEnd {
-                let bytesToRemove = Int(round(Double(lastEnd - currentStart) * Double(header.samplesPerSecond))) * Int(header.sampleSize)
+                let bytesToRemove = Int(ceil(Double(lastEnd - currentStart) * Double(header.samplesPerSecond))) * Int(header.sampleSize)
                 last.removeFromEnd(bytesToRemove)
                 last.append(samples: data.samples)
                 return

--- a/ios/Lift/Device/SensorData.swift
+++ b/ios/Lift/Device/SensorData.swift
@@ -465,7 +465,11 @@ class SensorData {
     ///
     /* mutating */
     func removeFromEnd(count: Int) {
-        samples.length -= count
+        if samples.length > count {
+            samples.length -= count
+        } else {
+            samples.length = 0
+        }
     }
     
     ///

--- a/ios/Lift/Device/SensorData.swift
+++ b/ios/Lift/Device/SensorData.swift
@@ -318,7 +318,14 @@ class SensorDataArray {
     /* mutating */
     func append(sensorData data: SensorData, maximumGap gap: CFTimeInterval, gapValue: UInt8) {
         if var last = sensorDatas.last {
-            if data.startTime - last.endTime(header.sampleSize, samplesPerSecond: header.samplesPerSecond) < gap {
+            let currentStart = data.startTime
+            let lastEnd = last.endTime(header.sampleSize, samplesPerSecond: header.samplesPerSecond)
+            if currentStart < lastEnd {
+                let bytesToRemove = Int(round(Double(lastEnd - currentStart) * Double(header.samplesPerSecond))) * Int(header.sampleSize)
+                last.removeFromEnd(bytesToRemove)
+                last.append(samples: data.samples)
+                return
+            } else if currentStart - lastEnd < gap {
                 last.padEnd(header.sampleSize, samplesPerSecond: header.samplesPerSecond, gapValue: gapValue, until: data.startTime)
                 last.append(samples: data.samples)
                 return
@@ -451,6 +458,14 @@ class SensorData {
     /* mutating */
     func append(samples data: NSData) {
         samples.appendData(data)
+    }
+    
+    ///
+    /// Removes ``count`` bytes from the end of the sample
+    ///
+    /* mutating */
+    func removeFromEnd(count: Int) {
+        samples.length -= count
     }
     
     ///


### PR DESCRIPTION
Issue https://github.com/eigengo/lift/issues/92

----
* [x] Allow overwrite "older" samples with currently received ones. (This way gaps in the data will not cause continuous samples to "run away to the future" indefinitely.)
* [x] Find the cause of the difference of the packet counts on devices.
* [x] Create quick patch
* [x] Ready for review.

----
A followup issue can be opened when we got some info back from the PebbleKit team.